### PR TITLE
Sistemato il flag isDefault che è diventato main

### DIFF
--- a/src/main/java/backend/dto/indirizzo_utente/CreateUserAddressDTO.java
+++ b/src/main/java/backend/dto/indirizzo_utente/CreateUserAddressDTO.java
@@ -14,7 +14,7 @@ public record CreateUserAddressDTO (
         String citta,
         String provincia,
         String nazione,
-        boolean isDefault,
+        boolean main,
         TipologiaIndirizzo tipologia
 ) implements Serializable {
 }

--- a/src/main/java/backend/dto/indirizzo_utente/ResponseUserAddressDTO.java
+++ b/src/main/java/backend/dto/indirizzo_utente/ResponseUserAddressDTO.java
@@ -18,7 +18,7 @@ public record ResponseUserAddressDTO (
         String citta,
         String provincia,
         String nazione,
-        boolean isDefault,
+        boolean main,
         TipologiaIndirizzo tipologia
 ) implements Serializable {
 }

--- a/src/main/java/backend/dto/indirizzo_utente/UpdateUserAddressDTO.java
+++ b/src/main/java/backend/dto/indirizzo_utente/UpdateUserAddressDTO.java
@@ -14,7 +14,7 @@ public record UpdateUserAddressDTO (
         String citta,
         String provincia,
         String nazione,
-        boolean isDefault,
+        boolean main,
         TipologiaIndirizzo tipologia
 )implements Serializable {
 }

--- a/src/main/java/backend/mapper/UserAddressMapper.java
+++ b/src/main/java/backend/mapper/UserAddressMapper.java
@@ -11,17 +11,14 @@ public interface UserAddressMapper extends GenericMapper<IndirizzoUtente, Create
 
 
     @Override
-    @Mapping(source = "isDefault", target = "default")
     IndirizzoUtente fromCreateDto(CreateUserAddressDTO createDTO);
 
     @Override
     @InheritConfiguration(name = "fromCreateDto")
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    @Mapping(source = "isDefault", target = "default")
     IndirizzoUtente partialUpdateFromCreate(CreateUserAddressDTO createUserAddressDTO, @MappingTarget IndirizzoUtente indirizzoUtente);
 
     @Override
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    @Mapping(source = "isDefault", target = "default")
     IndirizzoUtente partialUpdateFromUpdate(UpdateUserAddressDTO updateUserAddressDTO, @MappingTarget IndirizzoUtente indirizzoUtente);
 }

--- a/src/main/java/backend/model/IndirizzoUtente.java
+++ b/src/main/java/backend/model/IndirizzoUtente.java
@@ -25,8 +25,8 @@ public class IndirizzoUtente {
     private String provincia;
     private String nazione;
 
-    @Column(name = "is_default")
-    private boolean isDefault;
+    @Column(name = "is_main")
+    private boolean main;
 
     @Enumerated(EnumType.STRING)
     private TipologiaIndirizzo tipologia;

--- a/src/main/java/backend/repository/IndirizzoUtenteRepository.java
+++ b/src/main/java/backend/repository/IndirizzoUtenteRepository.java
@@ -15,4 +15,6 @@ public interface IndirizzoUtenteRepository extends JpaRepository<IndirizzoUtente
 
     @Query ("SELECT iu FROM IndirizzoUtente iu WHERE iu.id = :addressId AND iu.utente.id = :authUserId")
     Optional<IndirizzoUtente> findByIdAndUtenteId(UUID addressId, UUID authUserId);
+
+    Optional<IndirizzoUtente> findByUtenteIdAndMainTrue(UUID userId);
 }

--- a/src/main/resources/db/changelog/migration/32-05-changeIsDefaultToIsMainINIndirizzoUtente.sql
+++ b/src/main/resources/db/changelog/migration/32-05-changeIsDefaultToIsMainINIndirizzoUtente.sql
@@ -1,0 +1,10 @@
+-- liquibase formatted sql
+
+-- changeset riccardo:1756210658895-1
+ALTER TABLE indirizzo_utente
+    ADD is_main BOOLEAN;
+
+-- changeset riccardo:1756210658895-2
+ALTER TABLE indirizzo_utente
+    DROP COLUMN is_default;
+


### PR DESCRIPTION
ATTENZIONE
In tutti i dto di indirizzo utente il campo isDefault è stato rinominato in "main" perchè isDefault era un nome che al sistema creava ambiguità e problemi

Con questa PR, quando da un update o create indirizzo arriva un main=true il backend si prende carico di rimuovere, se esiste, il flag main=true di un indirizzo gia esistente nel db portandolo a false, garantendo la presenza di un solo main=true per ogni utente.

main è il campo che indica l'entità di default per quell'utente 